### PR TITLE
Fix issue #47

### DIFF
--- a/correlation/correlation.py
+++ b/correlation/correlation.py
@@ -247,7 +247,7 @@ def cupy_kernel(strFunction, objVariables):
 		strTensor = objMatch.group(4)
 		intSizes = objVariables[strTensor].size()
 		if torch.is_tensor(intSizes[intArg]):
-		    strKernel = strKernel.replace(objectMatch.group(), str(intSizes[intArg].detach().item()))
+		    strKernel = strKernel.replace(objectMatch.group(), str(intSizes[intArg].item()))
 		else:
 		    strKernel = strKernel.replace(objectMatch.group(), str(intSizes[intArg]))
 	# end

--- a/correlation/correlation.py
+++ b/correlation/correlation.py
@@ -246,8 +246,10 @@ def cupy_kernel(strFunction, objVariables):
 
 		strTensor = objMatch.group(4)
 		intSizes = objVariables[strTensor].size()
-
-		strKernel = strKernel.replace(objMatch.group(), str(intSizes[intArg]))
+		if torch.is_tensor(intSizes[intArg]):
+		    strKernel = strKernel.replace(objectMatch.group(), str(intSizes[intArg].detach().item()))
+		else:
+		    strKernel = strKernel.replace(objectMatch.group(), str(intSizes[intArg]))
 	# end
 
 	while True:


### PR DESCRIPTION
This fixes issue #47 and allows Tensorboard's `SummaryWriter.add_graph` to work although there are some TracerWarnings.

The problem was that the trace injects tensors into the `correlation` functions and in this case it was putting the word `tensor` in the Cupy code when the string replace was being done.

ie:
```python
float fltValue = input[(((intSample * tensor(196)) + intChannel) * tensor(6) * tensor(20)) + intIndex];
```
instead of:
```python
float fltValue = input[(((intSample * 196) + intChannel) * 6 * 20) + intIndex];
```

The following warning still occurs but it seems it can be ignored as they are all in the `correlation` function and it couldn't be shown in the model anyway.
`TracerWarning: Converting a tensor to a Python number might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!`