### PR TITLE
fix CUDA_ERROR_ILLEGAL_ADDRESS bug

### DIFF
--- a/correlation/correlation.py
+++ b/correlation/correlation.py
@@ -381,7 +381,8 @@ class _FunctionCorrelation(torch.autograd.Function):
 # end
 
 def FunctionCorrelation(tenOne, tenTwo):
-    return _FunctionCorrelation.apply(tenOne, tenTwo)
+    with cupy.cuda.Device(tenOne.get_device()):
+        return _FunctionCorrelation.apply(tenOne, tenTwo)
 # end
 
 class ModuleCorrelation(torch.nn.Module):


### PR DESCRIPTION
I fix the memory access bug, which describe here #55 . I force cupy allocate memory on pytorch device.